### PR TITLE
Add internal regulations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,13 @@ FILTER = config/custom-links.lua
 BUILD_FOLDER = build
 STATUTES_MD = statutes.md
 RULES_MD = rules-of-procedure.md
+INTERNAL_REGULATIONS_MD = internal-regulations.md
 STATUTES_PDF = statutes.pdf
 RULES_PDF = rules-of-procedure.pdf
+INTERNAL_REGULATIONS_PDF = internal-regulations.pdf
 
 # Default target
-all: $(BUILD_FOLDER)/$(STATUTES_PDF) $(BUILD_FOLDER)/$(RULES_PDF)
+all: $(BUILD_FOLDER)/$(STATUTES_PDF) $(BUILD_FOLDER)/$(RULES_PDF) $(BUILD_FOLDER)/$(INTERNAL_REGULATIONS_PDF)
 
 # Ensure the build folder exists
 $(BUILD_FOLDER):
@@ -31,6 +33,15 @@ $(BUILD_FOLDER)/$(STATUTES_PDF): $(STATUTES_MD) $(HEADER) $(FILTER) | $(BUILD_FO
 # Rule for rules of procedure PDF
 $(BUILD_FOLDER)/$(RULES_PDF): $(RULES_MD) $(HEADER) $(FILTER) | $(BUILD_FOLDER)
 	$(PANDOC) $(RULES_MD) -o $(BUILD_FOLDER)/$(RULES_PDF) \
+		--pdf-engine=$(PDF_ENGINE) \
+		--number-sections \
+		-V fontsize=$(FONT_SIZE) \
+		-H $(HEADER) \
+		--lua-filter=$(FILTER)
+
+# Rule for internal regulations PDF
+$(BUILD_FOLDER)/$(INTERNAL_REGULATIONS_PDF): $(INTERNAL_REGULATIONS_MD) $(HEADER) $(FILTER) | $(BUILD_FOLDER)
+	$(PANDOC) $(INTERNAL_REGULATIONS_MD) -o $(BUILD_FOLDER)/$(INTERNAL_REGULATIONS_PDF) \
 		--pdf-engine=$(PDF_ENGINE) \
 		--number-sections \
 		-V fontsize=$(FONT_SIZE) \

--- a/internal-regulations.md
+++ b/internal-regulations.md
@@ -3,11 +3,6 @@ title: Internal Regulations of the International Federation of Liberal Youth
 date: Draft proposal
 ---
 
----
-title: Internal Regulations of the International Federation of Liberal Youth
-date: Draft proposal
----
-
 # Membership
 
 ## Rights
@@ -37,6 +32,38 @@ All membership applications must be received by the IFLRY office at least two we
 
 Successful applicants are able to execute their rights after the meeting has closed all membership issues. All changes to the membership will be added to a Membership Register, which is under the responsibility of the Bureau.
 
+## Qualifying criteria
+
+### Full membership 
+To qualify for full membership, an organization must:
+
+(a) the organisation is a national youth organisation, or a sub-national youth organisation that is not part of a national organisation;
+(b) the organisation is not a member of any other pan-international political organisation that is not based on the ideas of the Manifesto;
+(c) it must be run by and for young people
+(d) it must be democratically organised
+(e) it must be in agreement with the aims of IFLRY
+(f) it must have been previously an associate member organisation of IFLRY.
+
+### Associate membership
+To qualify for associate membership, an organization must comply with points a through e of the full membership article.
+
+### Observer membership
+To qualify for observer membership, an organization must comply with points a, b, d, and e of the full membership article, and:
+
+(g) be run for young people.
+
+### Regional membership
+To qualify for regional membership, an organization must comply with all points of the full membership article.
+
+### Individual Membership
+Everyone, aged between 18 and 35 years, who broadly agree with the Manifesto and agrees with the aims of IFLRY, can become individual members of IFLRY.
+
+## Suspension
+
+Members of the Federation may be temporarily suspended if the targeted member organization is suspected of breaching any of the membership obligations. A motion to suspend a member can be submitted by the Bureau or two full members and needs to be submitted four weeks prior to the start of the General Assembly. Members need to be informed about this motion three weeks prior to the start of the statutory event.
+
+The suspension from the Federation is to be decided by a two-thirds majority. Each suspension is valid for a maximum of one year and may be revoked at any time by the relevant statutory body.
+
 ## Termination
 
 The members can leave the Federation on the following conditions:
@@ -54,7 +81,48 @@ The expulsion from the association is to be decided by a two-thirds majority of 
 
 ## Responsibilities
 
-The Bureau members will be mutually responsible for all its activities. The President, Secretary General and Treasurer function as the core-three responsible for the day-to-day activities of the Federation.
+The Bureau members will be mutually responsible for all its activities. The President, Secretary General and Treasurer function as the core-three responsible for the day-to-day activities of the Federation. All bureau members each have a single vote and bureau decisions require a simple majority of votes.
+
+### President
+The President is responsible for:
+
+(a) chairing the meetings of the Bureau;
+(b) preparing the agenda for Bureau meetings in consultation with the Secretary General;
+(c) managing external contacts;
+(d) ensuring a productive working environment within the Bureau;
+(e) ensuring that they are properly and fully informed at all times.
+
+### Secretary General
+The Secretary General is responsible for:
+
+(a) maintaining the membership administration;
+(b) implementing information and archive policies, as well as managing all related matters;
+(c) preparing minutes of Bureau meetings and General Assemblies;
+(d) managing internal and external privacy policies
+
+### Treasurer
+The Treasurer is responsible for:
+
+(a) collecting membership fees;
+(b) general financial policy;
+(c) preparing the annual financial report;
+(d) properly reporting on budget implementation to the Bureau and the Auditors, as often as deemed necessary, but at least once per quarter;
+(e) facilitating financial audits;
+(f) authorizing Bureau commitments, with approval from the Executive Committee where necessary.
+
+### Vice-presidents
+
+Vice-presidents are responsible but not limited to the following responsibilities, which shall be divided under the vice-presidents:
+
+(a) Events
+(b) Communication
+(c) Programme
+(d) Social Media/Marketing
+(e) Fundraising
+(f) Strategy
+(g) Libel?
+
+Newly elected Vice Presidents need to communicate their areas of responsibility to the IFLRY Member Organizations after the first Bureau meeting of their terms in office.
 
 ## Term {#bureau-term}
 The President, the Secretary General and Treasurer are elected for the period of two years until the next General Assembly. The four Vice Presidents are elected for the period of one year until the next General Assembly. Notwithstanding the right of the General Assembly to put the Bureau on question and to force Bureau Members to resign.
@@ -144,3 +212,92 @@ It is the responsibility of the ombudsperson to make their annual report availab
 
 # Office {#office}
 The Office shall submit a written report to the member organizations on its activities two weeks before the start of the General Assembly. This report will reflect the work carried out by the Office, including the Executive Director and other staff and will be presented at the General Assembly.
+
+# Candidacy
+
+## Eligibility
+
+Every member of a full member organisation can be nominated for a position in the Bureau or ombudsperson.
+Bureau members and the ombudsperson must be between 18 and 35 years old when they are elected.
+
+## Incompatibility of functions
+
+### Bureau member
+Being a Bureau member is incompatible with:
+
+(a) Being an auditor
+(b) Being an ombudsperson
+(c) Membership in the Advisory Council
+(d) Membership in the Office
+(e) Acting as a delegate of a (voting) member organization
+
+### Auditor
+Being an auditor is incompatible with being a Bureau member, as well as with points d and e of the above article.
+
+### Ombudsperson
+Being an ombudsperson is incompatible with being a Bureau member, as well as with points d and e of the above article.
+
+### Advisory Council
+Membership in the Advisory Council is incompatible with being a Bureau member, as well as with points a, d, and e of the above article and to ensure an adequate understanding of the workings of an organisation like IFLRY, a candidate for AC membership:
+
+(f) must have at least two years of experience in an elected or managerial position in the liberal network.
+
+### Office
+Membership in the Office is incompatible with being a Bureau member, as well as with points a, b, c, d, and e of the above article.
+
+### Acting as a delegate
+Acting as a delegate is incompatible with being a Bureau member, as well as with points a, b, c, d, and e of the above article.
+
+# Crisis Management
+
+A crisis is an exceptional situation that significantly disrupts IFLRY’s ability to function, requiring urgent action.
+
+## Global Crises
+
+A global crisis is an exceptional, worldwide situation that significantly disrupts IFLRY’s ability to function, particularly preventing international travel and in-person meetings.
+
+A global crisis that justifies crisis management must be:
+
+- Global in nature (not limited to a specific country or region).
+- Prolonged and unavoidable, making in-person meetings impossible for a significant portion of the Bureau or member organizations.
+- Affecting multiple regions, preventing fair participation
+
+## Internal Crises
+
+An internal financial crisis occurs when IFLRY lacks the necessary funds to sustain its core operations, including:
+
+- A severe funding shortfall affecting staff salaries, event organization, or administrative costs.
+- Loss of major funding sources, such as institutional grants or partner contributions.
+- Debts or financial mismanagement that put IFLRY at risk of insolvency.
+
+## Statutory meetings
+
+Elections may only be postponed in the event of a global crisis that makes holding a fair elections impossible.
+
+In the event of a crisis, it is expected that statutory meetings will be moved online, ensuring organizational continuity.
+
+The decision to move a meeting online must be made by the Bureau based on objective criteria and communicated transparently to member organizations.
+
+### Prevention
+
+After a crisis, the Bureau shall review its response and update contingency plans to improve future preparedness.
+
+# Intellectual Property
+
+## Ownership
+The name, logo, and other visual identifiers of IFLRY are the exclusive property of the organization. The use of IFLRY's intellectual property must align with the organization's values, mission, and regulations.
+
+## Usage Rights
+Member organizations and affiliates may use the IFLRY logo and name in accordance with branding guidelines, provided they do not misrepresent their relationship with IFLRY. Individual members and third parties must seek prior approval from the Bureau before using the organization's name or logo in any official capacity.
+
+## Protection and Enforcement
+The Bureau is responsible for overseeing the appropriate use of IFLRY's intellectual property. Unauthorized or misleading use of IFLRY's name or logo may result in corrective action. Any disputes concerning the use of IFLRY's intellectual property shall be reviewed by the Bureau.
+
+
+# Data Protection
+
+The association is committed to protecting personal data in line with applicable laws. Personal data will only be collected for legitimate purposes and kept secure.
+
+## Data Protection Officer
+
+The Bureau will appoint a Data Protection Officer (DPO) to oversee data protection practices. The DPO will ensure data is handled securely, especially for sensitive information like visa applications.

--- a/internal-regulations.md
+++ b/internal-regulations.md
@@ -1,0 +1,4 @@
+---
+title: Internal Regulations of the International Federation of Liberal Youth
+date: Draft proposal
+---

--- a/internal-regulations.md
+++ b/internal-regulations.md
@@ -2,3 +2,145 @@
 title: Internal Regulations of the International Federation of Liberal Youth
 date: Draft proposal
 ---
+
+---
+title: Internal Regulations of the International Federation of Liberal Youth
+date: Draft proposal
+---
+
+# Membership
+
+## Rights
+
+All members have the right of information within the federation.
+Regional members have the right to appoint a representative to the Bureau as Regional Bureau Member, but do not have voting rights in the Bureau.
+
+The rights of Members on the decision-making procedures, as well as the nomination procedures within the federation are stipulated in the Rules of Procedure.
+
+## Obligations
+
+All members commit themselves to fulfilling the following membership obligations:
+
+(a) To adhere to the financial obligations as stated in the Membership Fee Statute. Organisations and individual members, which have fulfilled these obligations, are considered in good standing, and;
+(b) To uphold the values as stated in the Manifesto.
+(c) To support the work being done by the statutory bodies of the Federation.
+
+### Changes
+
+If a member organization changes its name, or has merged with another organization which is not a member, the membership is not automatically transferred to the new or differently named entity. Member organizations need to inform the Bureau of any merger with a different organization. The Bureau will decide on the membership status transfer, subject to confirmation by the General Assembly. Member organizations need to inform the Bureau of any name change. The Bureau will decide on the membership name change, subject to confirmation by the General Assembly.
+
+## Admissions
+
+The admission of new members is subject to the following conditions: Full membership and Regional membership can only be granted by a two-thirds majority of those present and voting at the General Assembly, including abstentions. Associate membership can be granted by a simple majority vote of the General Assembly. Observer status can be granted by a simple majority vote of the General Assembly and needs to be renewed each year.
+
+All membership applications must be received by the IFLRY office at least two weeks prior to the start of the General Assembly at which the applicant organization wishes their application to be considered. The IFLRY Office will make sure that all submitted documents will be available to the members at least one week before the start of the General Assembly.
+
+Successful applicants are able to execute their rights after the meeting has closed all membership issues. All changes to the membership will be added to a Membership Register, which is under the responsibility of the Bureau.
+
+## Termination
+
+The members can leave the Federation on the following conditions:
+
+(a) The members of the Federation can resign by themselves.
+(b) The members of the Federation can be expelled.
+
+A request for voluntary resignation by a member organization needs to be filed with the Bureau through an official representative of the member organization. The General Assembly validates this request before the member organization is deregistered. In a case of the General Assembly not confirming the termination request, the membership will terminate at the end of the calendar year. A motion to expel a member can be submitted by the Bureau or two full members and needs to be submitted four weeks prior to the start of the General Assembly. Such a motion can be submitted if the targeted member organization is suspected of breaching any of the membership obligations.
+
+Members need to be informed about this motion three weeks prior to the start of the statutory event. The Bureau is required to put forward a motion for the expulsion of any member which has retained candidate membership status for four years.
+
+The expulsion from the association is to be decided by a two-thirds majority of those present and voting at the General Assembly. Members that are no longer part of the association have no rights to the financial assets.
+
+# Bureau
+
+## Responsibilities
+
+The Bureau members will be mutually responsible for all its activities. The President, Secretary General and Treasurer function as the core-three responsible for the day-to-day activities of the Federation.
+
+## Term {#bureau-term}
+The President, the Secretary General and Treasurer are elected for the period of two years until the next General Assembly. The four Vice Presidents are elected for the period of one year until the next General Assembly. Notwithstanding the right of the General Assembly to put the Bureau on question and to force Bureau Members to resign.
+
+## Obligations {#bureau-obligations}
+
+### Action Plan {#bureau-action-plan}
+Every newly elected Bureau shall draft an Action Plan for the whole mandate within the next two months after its election. This Plan of Action will be sent to the member organizations no later than these two months after the General Assembly. The Action Plan will be adopted at the first General Assembly after the General Assembly in which the Bureau is elected.
+
+### Annual and Interim Report {#bureau-annual-interim-report}
+The Bureau will have to submit for adoption once a year an Annual Report at least four weeks before the start of the General Assembly. The Annual Report outlines the achievements of the organization in relation to the objectives laid down in the Action Plan. The Annual Report will be presented by the President.
+
+If there is more than one statutory meeting every year, the Bureau will present an interim report to show what the current status of the realisation of the Action Plan is.
+
+### Bureau Reports {#bureau-reports}
+The Bureau is required to submit a written report to the member organizations on its activities four weeks before the start of the General Assembly. This report will reflect the work carried out by each individual Bureau member and will be presented at the General Assembly.
+
+## Suspension
+
+A quorum of more than 50% of the Bureau members with voting rights is needed in order for a decision to be valid.
+
+If a Bureau member fails to attend more than three Bureau Meetings in a row, without explaining the reason for not attending, their position will be discussed by the Bureau. The Bureau may suspend the Bureau member in question, by a two-thirds majority vote.
+
+Moreover, the Bureau can also call a vote to suspend a Bureau member if that member has become a serious liability to IFLRY’s reputation, is suspected of some serious misconduct, or is suspected of fraudulent behaviour. Such a vote has to be called for by at least three Bureau members, and announced to the Bureau and MOs at least two weeks before the Bureau vote for suspension. The announcement has to include the grounds on which the three Bureau members believe this paragraph to be applicable. For this vote the member who is proposed to be suspended has no vote, and the vote is carried if and only if no present Bureau member votes against it, and a majority of Bureau votes cast being in favour (counting present abstentions as votes cast).
+
+A suspension removes a Bureau member from his or her position up to and including the next GA, unless a simple majority of the Bureau vote to remove the suspension. In a case where the suspension still stands, there will be a vote of no confidence against the suspended member organized as per the Rules of Procedure at the next General Assembly. If the motion of no-confidence fails the member is reinstated. If a motion of no-confidence is carried, elections are organized as per the Rules of Procedure.
+
+If a Bureau member is suspended, the subsequent vacant position can be filled by the remaining bureau, under the same regulations as that for resigning Bureau members under the Rules of Procedure.
+
+# Advisory Council {#ac}
+
+The Advisory Council (AC) consists of three members appointed by the General Assembly for a period of two years and are allowed to serve no more than two consecutive terms. 
+
+Its function is to advise and support the Bureau, and to report to the General Assembly about the functioning of the Federation jointly with the Bureau. The AC has no decision-making powers when it comes to the running of the Federation.
+
+## Chair
+The AC will elect a chair after every change in its membership, or whenever it sees fit. The chair will be elected by a simple majority. The AC will see to it that the result of this election is related to the Bureau, the Office and the Member Organisations.
+
+## Term
+A member of the AC is elected for a period of two years until the next General Assembly. A member can then decide on their own to serve another term. This decision has to be confirmed by the General Assembly. They can however serve no more than two consecutive terms.
+
+## Responsibilities
+
+### Action Plan
+As specified in [article](#bureau-action-plan), the AC will provide feedback and advice to the Bureau about its draft Action Plan before it is sent to the member organisations.
+
+### Guidance and support with individual projects
+At the request of the Bureau, the AC can be called upon to provide guidance and support on specific topics. This could be the development of a project the Bureau wants to implement, guiding meetings, and providing the Bureau with support when communicating with external parties. The AC will offer support whenever appropriate. The Bureau can approach the AC for support at any time.
+
+### Relations with the Bureau
+The Secretary-General will keep the AC informed on issues within the Bureau, even when they can be
+resolved without the AC’s involvement. However it is not the job of the AC to manage the Bureau, but merely to observe, give advice and offer help when appropriate.
+
+### Regular meeting AC and SG/G3
+In order to facilitate the AC in the execution of the above-named tasks, the Secretary-General will have a meeting with the AC at least once every three months. The President and Treasurer are also entitled to join this meeting. In addition, a meeting will be held with the outgoing SG after the handover to a new Bureau. The outgoing President and Treasurer are also entitled to attend this meeting. The exact moments these meetings occur will be decided jointly by the AC and SG/G3 (i.e. President, SG and Treasurer), but they should be held within this timeframe:
+
+- In the first quarter after the election of the Bureau: finalise the Action Plan
+- In the second quarter: general progress
+- In the third: general progress
+- In the fourth: evaluate year one
+- In the fifth: finalise the updated Action Plan
+- In the sixth: general progress
+- In the seventh: general progress
+- In the eighth: evaluate term of the Bureau 
+
+## Obligations
+
+### Relationship to the GA
+No later than four weeks before every General Assembly, the AC and the Bureau will submit joint reports on the overall performance of the Federation, which includes the progress on the Action Plan and reports by every Bureau member on their work since the last General Assembly. For a more detailed description of the process, see [article](#bureau-annual-interim-report) and [article](#bureau-reports).
+
+### Recommending new members
+If there are vacancies on the AC, the AC has a duty to recommend new members to the General Assembly.
+
+## Suspension
+
+If an AC member fails to attend more than three AC meetings in a row, without explaining the reason for not attending, their position will be discussed by the AC. The AC may suspend the AC member in question, by a two-thirds majority vote.
+
+Moreover, the AC can also call a vote to suspend an AC member if that member has become a serious liability to IFLRY’s reputation, is suspected of some serious misconduct, or is suspected of fraudulent behaviour. Such a vote can be called for by any AC member and has to be announced to the Bureau and MOs at least two weeks before the AC vote for suspension. The announcement has to include the grounds on which the AC member(s) believe this paragraph to be applicable. For this vote, the member who is proposed to be suspended has no vote, and the vote is carried if and only if no present AC member votes against it, and a majority of AC members’ votes cast being in favour (counting present abstentions as votes cast).
+
+A suspension removes an AC member from his or her position up to and including the next GA unless a simple majority of the AC votes to lift the suspension. In a case where the suspension still stands, there will be a vote of no confidence against the suspended member organised as per the Rules of Procedure at the next General Assembly. If the motion of no-confidence fails the member is reinstated. If a motion of no-confidence is carried out, a replacement will be appointed by the GA as per the Rules of Procedure.
+
+# Auditors {#auditors}
+It is the responsibility of the auditors to make their annual report available once a year to the member organizations two weeks before the General Assembly takes place.
+
+# Ombudsperson {#ombudsperson}
+It is the responsibility of the ombudsperson to make their annual report available once a year to the member organizations two weeks before the General Assembly takes place.
+
+# Office {#office}
+The Office shall submit a written report to the member organizations on its activities two weeks before the start of the General Assembly. This report will reflect the work carried out by the Office, including the Executive Director and other staff and will be presented at the General Assembly.

--- a/rules-of-procedure.md
+++ b/rules-of-procedure.md
@@ -5,12 +5,24 @@ date: As adopted by the 54th General Assembly in Tallinn, Estonia, 15th-17th of 
 
 # General {#gen}
 
+The General Assembly is the highest decision-making body of the Federation. At the beginning of each General Assembly, the draft agenda will be decided on, the minutes of the previous meeting will be put forward for adoption and the relevant officers are proposed for appointment. This part is always chaired by the Bureau. The draft Agenda shall be made available for the membership at least four weeks prior to the General Assembly, by the Bureau or, in the case of an Extraordinary General Assembly, by those who call the meeting.
+An invitation for the General Assembly must be circulated eight weeks prior to the General Assembly to the members via E-Mail.
+
 ## Languages {#gen-lang}
-The official languages of the association shall be English, French, and Spanish. In the case that no translation facilities are available the working language will be English. The mandatory language of the Statutes is German.
+The official languages of the association shall be English, French, and Spanish. In the case that no translation facilities are available the working language will be English.
 
-# Membership {#mem}
+## Interpretation
 
-## Membership Rights {#mem-rights}
+The interpretation of this document shall be subject to the ruling of the General Assembly. Where the Statutes or the Rules of Procedure cannot be applied, the General Assembly decides. In cases of contradiction between the Rules of Procedure and the Statutes of the association, the Statutes take precedence.
+
+## Amendments
+
+Every proposal that aims to change this document must be submitted to the Office at least four weeks prior to the General Assembly, or one week after the announcement of an Extraordinary General Assembly. The proposal is adopted if decided by a two-thirds majority.
+
+All changes to this document take effect immediately after the end of the General Assembly in which they are adopted.
+
+# Membership Rights {#mem-rights}
+
 Voting rights to a General Assembly (GA) are stipulated under [article](#ga-voting). Full members have the right to vote, the right to nominate candidates to the Bureau and auditor positions, the right to nominate officers, the right to put forward proposals and the right to submit amendments to all proposals.
 
 Associate members have the right to vote, nominate officers, the right to put forward proposals and the right to submit amendments to all proposals except when it concerns the Manifesto, Statutes, the Rules of Procedure or financial documents.
@@ -23,54 +35,23 @@ The Bureau wields the same rights as Full Members, except for voting rights at t
 
 The Individual Members' Group has the right to vote, the right to put forward proposals, and the right to submit amendments to all proposals except where it concerns the Manifesto, Statutes, the Rules of Procedure, or financial documents. For the purpose of defining rights and obligations elsewhere in the rules of procedure, individual members are considered to be members, but not member organizations.
 
-## Membership Application {#mem-application}
-The admission of new members is subject to the following conditions: Full membership and Regional membership can only be granted by a two-thirds majority of those present and voting at the General Assembly, including abstentions. Associate membership can be granted by a simple majority vote of the General Assembly. Observer status can be granted by a simple majority vote of the General Assembly and needs to be renewed each year.
-
-All membership applications must be received by the IFLRY office at least two weeks prior to the start of the General Assembly at which the applicant organization wishes their application to be considered. The IFLRY Office will make sure that all submitted documents will be available to the members at least one week before the start of the General Assembly.
-
-Successful applicants are able to execute their rights after the meeting has closed all membership issues. All changes to the membership will be added to a Membership Register, which is under the responsibility of the Bureau.
-
-## Suspension {#mem-suspension}
-Members of the Federation may be temporarily suspended if the targeted member organization is suspected of breaching any of the membership obligations. A motion to suspend a member can be submitted by the Bureau or two full members and needs to be submitted four weeks prior to the start of the General Assembly. Members need to be informed about this motion three weeks prior to the start of the statutory event.
-
-The suspension from the Federation is to be decided by a two-thirds majority. Each suspension is valid for a maximum of one year and may be revoked at any time by the relevant statutory body.
-
-## Termination {#mem-termination}
-The members can leave the Federation on the following conditions:
-
-(a) The members of the Federation can resign by themselves.
-(b) The members of the Federation can be expelled.
-
-A request for voluntary resignation by a member organization needs to be filed with the Bureau through an official representative of the member organization. The General Assembly validates this request before the member organization is deregistered. In a case of the General Assembly not confirming the termination request, the membership will terminate at the end of the calendar year. A motion to expel a member can be submitted by the Bureau or two full members and needs to be submitted four weeks prior to the start of the General Assembly. Such a motion can be submitted if the targeted member organization is suspected of breaching any of the membership obligations.
-
-Members need to be informed about this motion three weeks prior to the start of the statutory event. The Bureau is required to put forward a motion for the expulsion of any member which has retained candidate membership status for four years.
-
-The expulsion from the association is to be decided by a two-thirds majority of those present and voting at the General Assembly. Members that are no longer part of the association have no rights to the financial assets.
-
-## Membership Changes {#mem-changes}
-If a member organization changes its name, or has merged with another organization which is not a member, the membership is not automatically transferred to the new or differently named entity. Member organizations need to inform the Bureau of any merger with a different organization. The Bureau will decide on the membership status transfer, subject to confirmation by the General Assembly. Member organizations need to inform the Bureau of any name change. The Bureau will decide on the membership name change, subject to confirmation by the General Assembly.
-
-# General Assembly {#ga}
-The General Assembly is the highest decision-making body of the Federation. At the beginning of each General Assembly, the draft agenda will be decided on, the minutes of the previous meeting will be put forward for adoption and the relevant officers are proposed for appointment. This part is always chaired by the Bureau. The draft Agenda shall be made available for the membership at least four weeks prior to the General Assembly, by the Bureau or, in the case of an Extraordinary General Assembly, by those who call the meeting.
-An invitation for the General Assembly must be circulated eight weeks prior to the General Assembly to the members via E-Mail.
-
-## Quorum & Voting {#ga-quorum-voting}
+# Quorum & Voting {#ga-quorum-voting}
 A quorum of 33% of the votes of organizations in good standing shall be required to begin any meeting of a General Assembly.
 
 Decisions are taken by a simple majority of those present and voting, with abstentions being counted as not voting, unless otherwise stated. In the event of a tie vote a recount shall be taken. If there is still a    tie vote, the status quo shall persist.
 
 Decisions are only valid where half of the total votes present at the opening of the meeting are cast. Abstentions shall be included for this purpose.
 
-## Authority {#ga-authority}
+# Authority {#ga-authority}
 The General Assembly has the exclusive authority to decide on:
 
 (a) Membership Applications;
-(b) Amendments to the Statutes, Rules of Procedure and Manifesto;
+(b) Amendments to the Statutes, Rules of Procedure, Internal Regulations and Manifesto;
 (c) Expulsion of member organizations.
 
 Depending on the nature of the event, the officers for appointment may be Chairs, Secretaries and Returning Officers.
 
-## Delegations {#ga-delegations}
+# Delegations {#ga-delegations}
 Voting rights and procedure are stipulated in [article](#ga-voting). Each member organization shall be responsible for appointing their representatives to meetings of the General Assembly, provided that the representative is a member in good standing of the organization represented. A member organization may specify in writing to the Secretary General which of its representatives control voting rights for the organization. If no representative is specified in writing, any representative present that was nominated by the member organization shall be entitled to vote on its behalf.
 
 There shall be no limit to the number of delegates from member organizations attending the statutory meeting. Delegates are required to be nominated by their member organization and other attendees are required to register for attending the statutory meeting. However, the Bureau will only guarantee a full General Assembly arrangement for the number of votes per organization, unless otherwise stated.
@@ -102,33 +83,33 @@ The chair shall appoint three returning officers to administer elections and con
 
 The returning officers shall announce the deadline for nominations for auditors.
 
-## Elections {#ga-elections}
+# Elections {#ga-elections}
 For the Bureau elections and appointments to the Advisory Council, those candidacies are valid that were received in writing by the IFLRY office four weeks before the start of the General Assembly.
 
-### President, Secretary General and Treasurer elections {#ga-elections-g3}
+## President, Secretary General and Treasurer elections {#ga-elections-g3}
 The President, the Secretary General and the Treasurer shall be elected by simple majority vote. In the event none of the candidates to each of these positions receives more than 50% of the votes, there will  be additional rounds of voting until the required majority is achieved.
 
 In each of the additional rounds, those who receive the least number of votes, in such a way that even if the votes of those who received less than them could be added to their votes would not change their position, will not participate in the next round.
 
-### Vice President Elections {#ga-elections-vp}
+## Vice President Elections {#ga-elections-vp}
 The Vice Presidents of the organization shall be elected as follows: On each ballot paper the member organizations select the candidates that should be elected as Vice Presidents in such a way that they mark the names of their choice. Each marked candidate will receive one vote. Each member organization must vote on the same number of candidates as the number of positions that must be filled. Voting ballots that do not have the full number of candidates as positions that must be filled will be counted as invalid. The 4 candidates with the most votes are elected in the order of the amount of votes. Only candidates reaching the quorum defined by the following formula are elected: $\frac{1}{\text{the positions available for election} + 1}$ will be eligible for election, meaning i.e. that for four Vice President positions the quorum will be $\frac{1}{4 + 1} = 20\%$ of the total votes possible. For three positions the formula will be $\frac{1}{3 + 1} = 25\%$ of the total votes possible. For two positions the quorum will be $\frac{1}{2 + 1} = 33.33\%$ of the total votes possible. In case of only one vacant position for a round of election, the principle of simple majority shall be used, as is the case with the positions of President, Secretary General and Treasurer as well.  
 
 In case that there are not enough candidates reaching the quorum of the votes, a new round of voting will be held for the remaining place(s). If there are not enough candidates reaching the quorum in the second round of voting, the position will remain vacant until a new call for elections is issued at the next General Assembly. If there are more selections on the ballot paper than the number of the Vice President positions to be elected, the ballot paper is considered invalid. The ballot will also be invalid if it is not possible to identify the names on the ballot. If candidates receive an equal number of votes and it remains unclear which candidates shall be elected, then a second round of voting between these candidates is to be conducted using the above mentioned procedure. Should in this second round of voting, an equal number of votes remain, then lots will be drawn to determine the winner.
 
-### Auditor Elections {#ga-elections-auditor}
+## Auditor Elections {#ga-elections-auditor}
 For the election of auditors, the ballot can be filled with one or two names. Each name will count   as one vote. It is not possible to give more than one vote to one candidate on each ballot. The two candidates who received the highest number of votes shall be elected Auditors. In case of resignation of an Auditor, the next person on the last Auditor election results list sorted on highest number of votes will replace the vacancy.
 
-### Advisory Council Appointments {#ga-ac-appointment}
+## Advisory Council Appointments {#ga-ac-appointment}
 For the appointment of the first Advisory Council, Advisory Council members will be proposed by the Bureau to the General Assembly. After that, the Advisory council will propose new members to the General Assembly whenever an Advisory Council position becomes vacant. In both cases, they will be appointed by the General Assembly through a simple majority vote.
 
-### Expulsion and Replacement {#ga-elections-expulsion}
+## Expulsion and Replacement {#ga-elections-expulsion}
 It is the right of a General Assembly, both ordinary and extraordinary, to put the mandate of an elected person in question and to terminate that mandate following a motion of no-confidence with a two-thirds majority.
 
 Following an expulsion of an elected person it is the right of the General Assembly to immediately elect a replacement. The newly elected Bureau member or auditor will have a period of mandate that expires at the next General Assembly.
 
 In case of a resignation of a Bureau member, the Bureau has the power to appoint a replacement in a non-voting capacity until the next General Assembly, provided there is no meeting of the General Assembly in the following 30 days.
 
-### Timing {#ga-elections-timing}
+## Timing {#ga-elections-timing}
 
 Elections shall be held at the first General Assembly of the calendar year corresponding with the end of the Bureau members’ term. Notice of elections shall be given concurrently with notice of the GA.
 
@@ -136,31 +117,31 @@ The incoming Bureau members shall be installed in their roles at the close of th
 
 In elections where multiple rounds of voting are required, successive rounds shall be held immediately.
 
-## Agenda {#ga-agenda}
+# Agenda {#ga-agenda}
 The agenda of the statutory event may include proposals and reports. The agenda will be proposed to the membership four weeks before the General Assembly.
 
-### Organizational Proposals {#ga-org-proposals}
+## Organizational Proposals {#ga-org-proposals}
 Items which propose a change from the status quo. This can include, but is not limited to, organizational motions, the budget proposal, and amendments to the statutes and rules of procedure. The deadline for submitting organizational proposals is four weeks before the Statutory Meeting.
 
-### Political Proposals {#ga-political-proposals}
+## Political Proposals {#ga-political-proposals}
 Items which propose a change from the status quo. This can include, but is not limited to, resolutions and amendments to Manifesto. Except for the Manifesto proposals, the deadline for submitting proposals is two weeks before the General Assembly, and shall be made available to the member organizations no later than one week before the General Assembly. Manifesto proposals must be submitted four weeks before the General Assembly, and shall be made available to the member organizations no later than one week before the General Assembly.
 
 At the opening of the General Assembly, while adopting the agenda, the membership will vote on the prioritisation of the political proposals that have been submitted. Resolutions will be discussed following the list based on the number of votes, from highest number of votes, to lowest number of votes last.
 
-### Urgency Proposals {#ga-urgency-proposals}
+## Urgency Proposals {#ga-urgency-proposals}
 Those resolutions shall be dealt with, which, in the opinion of the General Assembly, could not have been proposed before the official deadline due to their urgent nature. Such resolutions should be submitted to the IFLRY Office before the beginning of the General Assembly, unless a two-thirds majority of those present and voting accept a later resolution as urgent.
 
-### Reports {#ga-reports}
+## Reports {#ga-reports}
 Items which report on the status quo. This includes Bureau reports, annual reports, financial reports and auditor reports. The deadline for submitting reports is two weeks before the Statutory Meeting.
 
-### Amendments {#ga-amendments}
+## Amendments {#ga-amendments}
 Only proposals may be amended by the statutory event.
 
 Only amendments that are submitted 24 hours prior to the opening of the meeting will be formally discussed, unless otherwise stated.
 
 Secondary amendments can be dealt with on the spot, if the respective Standing Committee agrees by simple majority.
 
-## Standing Committees {#ga-standing-committees}
+# Standing Committees {#ga-standing-committees}
 There are four Standing Committees which shall convene at each General Assembly, provided there are issues to discuss: Finances; Membership; Resolutions and Manifesto; and Statutes and Rules of Procedure. The role of the Standing Committees is to deliberate the issues in depth and to deliver a recommendation to the General Assembly.
 
 In each Standing Committee, the member organizations have one vote each, and only one delegate per member organization may contribute to the discussion and vote of each Standing Committee.
@@ -173,12 +154,12 @@ The Standing Committee on Finances shall discuss and review any proposed documen
 
 The Membership Fee Statute for each upcoming year shall be proposed by the Bureau and disseminated among the member organizations four weeks prior to the General Assembly. It shall include the calculation method for the membership fees, rules regarding reduced membership fee applications and other membership fee related issues.
 
-### Standing Committee on Membership {#ga-standing-committee-mem}
+## Standing Committee on Membership {#ga-standing-committee-mem}
 The Standing Committee on Membership shall deal with the relevant membership issues prior to their consideration by the GA. This may be membership applications, membership suspensions, membership expulsion, or other relevant issues.
 
 Any issues relating to the reported organization size, budget or voting rights shall be first reviewed by this committee before being considered by the GA.
 
-### Standing Committee on Resolutions and Manifesto {#ga-standing-committee-res}
+## Standing Committee on Resolutions and Manifesto {#ga-standing-committee-res}
 The Standing Committee on Resolutions and Manifesto shall deal with amendments to the Manifesto as well as Resolutions and Urgency Resolutions, prior to their consideration by the GA. In addition, the Committee shall on an ongoing basis provide a process for reviewing and if necessary, amending the Manifesto.
 
 The Chairs may decide upon a deadline for secondary amendments to the political proposals. Resolutions, urgency resolutions and amendments to those political proposals will be accepted by a simple majority. Amendments to the Manifesto will be adopted if accepted by a two-thirds majority of those present and voting.
@@ -189,18 +170,18 @@ In voting on amendments, the chair shall normally first hold a vote on the amend
 
 The proposer of a resolution may withdraw the resolution at any time before the vote takes place.
 
-### Standing Committee on Statutes and Rules of Procedure {#ga-standing-committee-rop}
+## Standing Committee on Statutes and Rules of Procedure {#ga-standing-committee-rop}
 The Standing Committee on Statutes and Rules of Procedure shall review any proposed amendments to the Statutes or Rules of Procedure prior to their consideration by the GA. In addition, the Committee on Rules shall propose additional rules as necessary covering each GA which shall be adopted immediately following the determination of a quorum at each GA.
 
-## Standing Orders {#ga-so}
+# Standing Orders {#ga-so}
 
-### Roll Call {#ga-so-roll-call}
+## Roll Call {#ga-so-roll-call}
 A roll call shall be taken at the opening of each GA session and if requested. It shall be taken in the English alphabetical order of countries in connection with the vote being undertaken.
 
-### List of Speakers {#ga-so-speakers}
+## List of Speakers {#ga-so-speakers}
 The chairperson may announce a list of speakers and with the consent of the General Assembly declare a list closed. The chairperson may announce a maximum time limit for contributions to the debate.
 
-### Procedural Points{#ga-procedural-points}
+## Procedural Points{#ga-procedural-points}
 
 The following is a limitative list of Procedural Points that can be made during the General Assembly or its standing procedures committees. These points can interrupt a speaker, are not required to be seconded, are not brought up for debate, and are not
 put to a vote.
@@ -212,7 +193,7 @@ These points shall be limited to:
 
 If the Chair deems an individual to be abusing their right to raise Procedural Points, the Chair should ask the individual to refrain from raising them until proceedings have moved on.
 
-### Procedural Motions {#ga-so-procedural-motions}
+## Procedural Motions {#ga-so-procedural-motions}
 Procedural Motions are required to be seconded unless otherwise stated, cannot interrupt speakers unless otherwise stated, will not be debated on unless otherwise stated, and shall require a simple majority to pass unless otherwise stated.
 
 The order of Procedural Motions shall be limited to:
@@ -228,103 +209,9 @@ The order of Procedural Motions shall be limited to:
 
 In debate on a Procedural Motion, the only speakers allowed shall be the mover of the motion and the mover of the resolution or amendment, who shall have the right to reply; if the motion is not raised during a resolution or an amendment, there shall be no right to reply. Should any of these motions passed during a Standing Committee have an effect external to the Standing Committee itself, it shall be brought as a recommendation to the General Assembly.
 
-### Minutes {#ga-so-minutes}
+## Minutes {#ga-so-minutes}
 The decisions of the General Assembly shall be entered in the minutes and will be made available to the members no later than 30 days following the adjournment of the General Assembly and shall be signed by one of the auditors. This falls under the responsibility of the two auditors.
 
 In the case of an Extraordinary General Assembly, no decisions on items not mentioned on the agenda can be taken.
 
 The minutes will be approved by the next General Assembly.
-
-# Bureau {#bureau}
-The Bureau members will be mutually responsible for all its activities. The President, Secretary General and Treasurer function as the core-three responsible for the day-to-day activities of the Federation.
-Newly elected Vice Presidents need to communicate their areas of responsibility to the IFLRY Member Organizations after the first Bureau meeting of their terms in office.
-
-A quorum of more than 50% of the Bureau members with voting rights is needed in order for a decision to be valid.
-
-If a Bureau member fails to attend more than three Bureau Meetings in a row, without explaining the reason for not attending, their position will be discussed by the Bureau. The Bureau may suspend the Bureau member in question, by a two-thirds majority vote.
-
-Moreover, the Bureau can also call a vote to suspend a Bureau member if that member has become a serious liability to IFLRY’s reputation, is suspected of some serious misconduct, or is suspected of fraudulent behaviour. Such a vote has to be called for by at least three Bureau members, and announced to the Bureau and MOs at least two weeks before the Bureau vote for suspension. The announcement has to include the grounds on which the three Bureau members believe this paragraph to be applicable. For this vote the member who is proposed to be suspended has no vote, and the vote is carried if and only if no present Bureau member votes against it, and a majority of Bureau votes cast being in favour (counting present abstentions as votes cast).
-
-A suspension removes a Bureau member from his or her position up to and including the next GA, unless a simple majority of the Bureau vote to remove the suspension. In a case where the suspension still stands, there will be a vote of no confidence against the suspended member organized as per the procedure in [article](#ga-elections-expulsion) at the next General Assembly. If the motion of no-confidence fails the member is reinstated. If a motion of no-confidence is carried, elections are organized as per the procedure in [article](#ga-elections-expulsion).
-
-If a Bureau member is suspended, the subsequent vacant position can be filled by the remaining bureau, under the same regulations as that for resigning Bureau members under [article](#ga-elections-expulsion).
-
-## Term {#bureau-term}
-The President, the Secretary General and Treasurer are elected for the period of two years until the next General Assembly. The four Vice Presidents are elected for the period of one year until the next General Assembly. Notwithstanding the right of the General Assembly to put the Bureau on question and to force Bureau Members to resign.
-
-## Bureau Obligations {#bureau-obligations}
-
-### Action Plan {#bureau-action-plan}
-Every newly elected Bureau shall draft an Action Plan for the whole mandate within the next two months after its election. This Plan of Action will be sent to the member organizations no later than these two months after the General Assembly. The Action Plan will be adopted at the first General Assembly after the General Assembly in which the Bureau is elected.
-
-### Annual and Interim Report {#bureau-annual-interim-report}
-The Bureau will have to submit for adoption once a year an Annual Report at least four weeks before the start of the General Assembly. The Annual Report outlines the achievements of the organization in relation to the objectives laid down in the Action Plan. The Annual Report will be presented by the President.
-
-If there is more than one statutory meeting every year, the Bureau will present an interim report to show what the current status of the realisation of the Action Plan is.
-
-### Bureau Reports {#bureau-reports}
-The Bureau is required to submit a written report to the member organizations on its activities four weeks before the start of the General Assembly. This report will reflect the work carried out by each individual Bureau member and will be presented at the General Assembly.
-
-# Advisory Council {#ac}
-The Advisory Council (AC) members will be mutually responsible for all its activities. If an AC member fails to attend more than three AC meetings in a row, without explaining the reason for not attending, their position will be discussed by the AC. The AC may suspend the AC member in question, by a two-thirds majority vote.
-
-Moreover, the AC can also call a vote to suspend an AC member if that member has become a serious liability to IFLRY’s reputation, is suspected of some serious misconduct, or is suspected of fraudulent behaviour. Such a vote can be called for by any AC member and has to be announced to the Bureau and MOs at least two weeks before the AC vote for suspension. The announcement has to include the grounds on which the AC member(s) believe this paragraph to be applicable. For this vote, the member who is proposed to be suspended has no vote, and the vote is carried if and only if no present AC member votes against it, and a majority of AC members’ votes cast being in favour (counting present abstentions as votes cast).
-
-A suspension removes an AC member from his or her position up to and including the next GA unless a simple majority of the AC votes to lift the suspension. In a case where the suspension still stands, there will be a vote of no confidence against the suspended member organised as per the procedure in [article](#ga-elections-expulsion) at the next General Assembly. If the motion of no-confidence fails the member is reinstated. If a motion of no-confidence is carried out, a replacement will be appointed by the GA as per the procedure in [article](#ga-ac-appointment).
-
-## Chair
-The AC will elect a chair after every change in its membership, or whenever it sees fit. The chair will be elected by a simple majority. The AC will see to it that the result of this election is related to the Bureau, the Office and the Member Organisations.
-
-## Term
-A member of the AC is elected for a period of two years until the next General Assembly. A member can then decide on their own to serve another term. This decision has to be confirmed by the General Assembly. They can however serve no more than two consecutive terms.
-
-## AC Responsibilities and Obligations
-
-### Action Plan
-As specified in [article](#bureau-action-plan), the AC will provide feedback and advice to the Bureau about its draft Action Plan before it is sent to the member organisations.
-
-### Guidance and support with individual projects
-At the request of the Bureau, the AC can be called upon to provide guidance and support on specific topics. This could be the development of a project the Bureau wants to implement, guiding meetings, and providing the Bureau with support when communicating with external parties. The AC will offer support whenever appropriate. The Bureau can approach the AC for support at any time.
-
-### Relations with the Bureau
-The Secretary-General will keep the AC informed on issues within the Bureau, even when they can be
-resolved without the AC’s involvement. However it is not the job of the AC to manage the Bureau, but merely to observe, give advice and offer help when appropriate.
-
-### Regular meeting AC and SG/G3
-In order to facilitate the AC in the execution of the above-named tasks, the Secretary-General will have a meeting with the AC at least once every three months. The President and Treasurer are also entitled to join this meeting. In addition, a meeting will be held with the outgoing SG after the handover to a new Bureau. The outgoing President and Treasurer are also entitled to attend this meeting. The exact moments these meetings occur will be decided jointly by the AC and SG/G3 (i.e. President, SG and Treasurer), but they should be held within this timeframe:
-
-- In the first quarter after the election of the Bureau: finalise the Action Plan
-- In the second quarter: general progress
-- In the third: general progress
-- In the fourth: evaluate year one
-- In the fifth: finalise the updated Action Plan
-- In the sixth: general progress
-- In the seventh: general progress
-- In the eighth: evaluate term of the Bureau 
-
-### Relationship to the GA
-No later than four weeks before every General Assembly, the AC and the Bureau will submit joint reports on the overall performance of the Federation, which includes the progress on the Action Plan and reports by every Bureau member on their work since the last General Assembly. For a more detailed description of the process, see [article](#bureau-annual-interim-report) and [article](#bureau-reports).
-
-### Recommending new members
-If there are vacancies on the AC, the AC has a duty to recommend new members to the General Assembly.
-
-### Eligibility
-To ensure an adequate understanding of the workings of an organisation like IFLRY, a candidate for AC membership must have at least two years of experience in an elected or managerial position in the liberal network.
-
-### Conflict of Interest
-To avoid any conflict of interest, AC members are not allowed to be active in IFLRY in any other capacity. Furthermore, they are only allowed to attend General Assemblies, and do so in an observatory capacity.
-
-# Auditors {#auditors}
-It is the responsibility of the auditors to make their annual report available once a year to the member organizations two weeks before the General Assembly takes place.
-
-# Ombudsperson {#ombudsperson}
-It is the responsibility of the ombudsperson to make their annual report available once a year to the member organizations two weeks before the General Assembly takes place.
-
-# Office {#office}
-The Office shall submit a written report to the member organizations on its activities two weeks before the start of the General Assembly. This report will reflect the work carried out by the Office, including the Executive Director and other staff and will be presented at the General Assembly.
-
-# Rules of Procedure {#rules-of-procedure}
-The interpretation of these Rules of Procedure shall be subject to the ruling of the General Assembly. Where the Statutes or the Rules of Procedure cannot be applied, the General Assembly decides. In cases of contradiction between the Rules of Procedure and the Statutes of the association, the Statutes take precedence.
-
-Every proposal that aims to change these Rules of Procedure must be submitted to the Office at least four weeks prior to the General Assembly, or one week after the announcement of an Extraordinary General Assembly. The proposal is adopted if decided by a two-thirds majority.
-All changes to the Rules of Procedure take effect immediately after the end of the General Assembly in which they are adopted.

--- a/statutes.md
+++ b/statutes.md
@@ -121,8 +121,7 @@ The association shall be represented towards third parties and in legal matters 
 
 ## Advisory Council {#ac}
 
-### General
-The Advisory Council (AC) is appointed by the general assembly to advise the Bureau. The composition, role, and terms are laid down in the Rules of Procedure.
+The Advisory Council is appointed by the general assembly to advise the Bureau. The composition, role, and terms are laid down in the Internal Regulations.
 
 # Auditors
 There shall be two auditors, who shall be elected at a General Assembly for a period of two years. They are responsible for examining the accounts and general finances of the Federation and assessing how the Bureau has carried out the decisions taken by the General Assembly. They shall produce a report at least annually which is presented to the General Assembly.


### PR DESCRIPTION
Introduce a draft for the internal regulations. 

I separated the steps into multiple commits:
- Moving the contents out of the RoP and into the IR where needed

And after that introduced several new sections, including:
- Intellectual property (use of logo, name)
- Crisis management
- Data Protection

also included is a revamped conflict of interest section that simplifies and clarifies what we have right now which can be all over the place and included Lina's edits for the membership admission criteria.