### PR TITLE
Resolution review clause

### DIFF
--- a/rules-of-procedure.md
+++ b/rules-of-procedure.md
@@ -124,6 +124,8 @@ Items which propose a change from the status quo. This can include, but is not l
 
 Manifesto proposals must be submitted four weeks before the General Assembly, and shall be made available to the member organisations no later than one week before the General Assembly.
 
+Resolutions adopted by the General Assembly shall remain valid for a period of four years from the date of adoption, after which they shall automatically expire unless re-adopted by the General Assembly as a new political proposal. This clause shall not apply to amendments to the Manifesto.
+
 At the opening of the General Assembly, while adopting the agenda, the membership will vote on the prioritisation of the political proposals that have been submitted. Resolutions will be discussed following the list based on the number of votes, from highest number of votes, to lowest number of votes last.
 
 ## Urgency Proposals {#urgency}

--- a/rules-of-procedure.md
+++ b/rules-of-procedure.md
@@ -124,7 +124,7 @@ Items which propose a change from the status quo. This can include, but is not l
 
 Manifesto proposals must be submitted four weeks before the General Assembly, and shall be made available to the member organisations no later than one week before the General Assembly.
 
-Resolutions adopted by the General Assembly shall remain valid for a period of four years from the date of adoption, after which they shall automatically expire unless re-adopted by the General Assembly as a new political proposal. This clause shall not apply to amendments to the Manifesto.
+Resolutions adopted by the General Assembly shall remain valid for a period of four years from the date of adoption, after which they shall automatically expire unless re-adopted by the General Assembly as a new political proposal. This clause shall not apply to amendments to the Manifesto. Four weeks prior to the General Assembly, the Bureau shall prepare and circulate a shortlist of resolutions due to expire.
 
 At the opening of the General Assembly, while adopting the agenda, the membership will vote on the prioritisation of the political proposals that have been submitted. Resolutions will be discussed following the list based on the number of votes, from highest number of votes, to lowest number of votes last.
 

--- a/rules-of-procedure.md
+++ b/rules-of-procedure.md
@@ -24,7 +24,7 @@ Voting rights to a General Assembly are stipulated under [article](#ga-voting). 
 
 Associate members have the right to vote, nominate officers, the right to put forward proposals and the right to submit amendments to all proposals except when it concerns the Manifesto, Statutes, the Rules of Procedure, Internal Regulations or financial documents.
 
-Regional members have the right to put forward resolutions and the right to submit amendments to all proposals except when it concerns the Manifesto, Statutes, the Rules of Procedure, Internal Regulations or financial documents. 
+Regional members have the right to put forward resolutions and the right to submit amendments to all proposals except when it concerns the Manifesto, Statutes, the Rules of Procedure, Internal Regulations or financial documents.
 
 Observer members have the right to observe, co-sign political proposals and their amendments and contribute to discussions on political proposals, but no right to vote, nominate candidates or put forward organisational proposals. Observer members are treated as non-
 voting members and therefore only have the right to observe the proceedings of the Federation and its General Assembly.

--- a/rules-of-procedure.md
+++ b/rules-of-procedure.md
@@ -124,7 +124,7 @@ Items which propose a change from the status quo. This can include, but is not l
 
 Manifesto proposals must be submitted four weeks before the General Assembly, and shall be made available to the member organisations no later than one week before the General Assembly.
 
-Resolutions adopted by the General Assembly shall remain valid for a period of four years from the date of adoption, after which they shall automatically expire unless re-adopted by the General Assembly as a new political proposal. This clause shall not apply to amendments to the Manifesto. Four weeks prior to the General Assembly, the Bureau shall prepare and circulate a shortlist of resolutions due to expire.
+Resolutions adopted by the General Assembly shall be subject to review four years after the date of adoption. Four weeks before each General Assembly the Bureau shall circulate a shortlist of resolutions due for review to the Standing Committee on Resolutions and Manifesto. The GA shall decide whether to archive or re-submit a reviewed resolution. Any amendments shall follow the normal procedures for political proposals. If no decision is taken, the resolution remains in force and will be placed on the agenda for review at the next GA.
 
 At the opening of the General Assembly, while adopting the agenda, the membership will vote on the prioritisation of the political proposals that have been submitted. Resolutions will be discussed following the list based on the number of votes, from highest number of votes, to lowest number of votes last.
 

--- a/rules-of-procedure.md
+++ b/rules-of-procedure.md
@@ -24,7 +24,7 @@ Voting rights to a General Assembly are stipulated under [article](#ga-voting). 
 
 Associate members have the right to vote, nominate officers, the right to put forward proposals and the right to submit amendments to all proposals except when it concerns the Manifesto, Statutes, the Rules of Procedure, Internal Regulations or financial documents.
 
-Regional members have the right to put forward resolutions and the right to submit amendments to all proposals except when it concerns the Manifesto, Statutes, the Rules of Procedure, Internal Regulations or financial documents.
+Regional members have the right to put forward resolutions and the right to submit amendments to all proposals except when it concerns the Manifesto, Statutes, the Rules of Procedure, Internal Regulations or financial documents. 
 
 Observer members have the right to observe, co-sign political proposals and their amendments and contribute to discussions on political proposals, but no right to vote, nominate candidates or put forward organisational proposals. Observer members are treated as non-
 voting members and therefore only have the right to observe the proceedings of the Federation and its General Assembly.

--- a/rules-of-procedure.md
+++ b/rules-of-procedure.md
@@ -124,7 +124,7 @@ Items which propose a change from the status quo. This can include, but is not l
 
 Manifesto proposals must be submitted four weeks before the General Assembly, and shall be made available to the member organisations no later than one week before the General Assembly.
 
-Resolutions adopted by the General Assembly shall be subject to review four years after the date of adoption. Four weeks before each General Assembly the Bureau shall circulate a shortlist of resolutions due for review to the Standing Committee on Resolutions and Manifesto. The GA shall decide whether to archive or re-submit a reviewed resolution. Any amendments shall follow the normal procedures for political proposals. If no decision is taken, the resolution remains in force and will be placed on the agenda for review at the next GA.
+Resolutions adopted by the General Assembly shall be subject to review four years after the date of adoption. Four weeks before each General Assembly the Bureau shall circulate a list of resolutions due for review to the Standing Committee on Resolutions and Manifesto. The GA shall decide whether to archive or re-submit a reviewed resolution. Any amendments shall follow the normal procedures for political proposals. If no decision is taken, the resolution remains in force and will be placed on the agenda for review at the next GA.
 
 At the opening of the General Assembly, while adopting the agenda, the membership will vote on the prioritisation of the political proposals that have been submitted. Resolutions will be discussed following the list based on the number of votes, from highest number of votes, to lowest number of votes last.
 


### PR DESCRIPTION
I would propose that at the first General Assembly following the adoption, a one-time *Review Working Group* would be created. This WG reviews existing resolutions adopted more than four years prior and proposes a list of the most important ones to be re-voted on at the following GA. 