### PR TITLE
Specify non-profit beneficiary for dissolution assets

### DIFF
--- a/statutes.md
+++ b/statutes.md
@@ -125,7 +125,7 @@ Every proposal that aims to dissolve the Federation must be put forward by the B
 
 The General Assembly will determine in which manner the Federation is dissolved and in which manner the dissolution is settled. 
 
-In case of dissolution, any remaining net assets of the AISBL shall be allocated to one or more non-profit legal persons pursuing a disinterested purpose similar to that of IFLRY, as designated by the General Assembly. Under no circumstances may the assets be returned to members or used for their benefit.
+In case of dissolution, any remaining net assets of the AISBL shall be allocated to one or more non-profit legal entities pursuing a disinterested purpose similar to that of IFLRY, as designated by the General Assembly. Under no circumstances may the assets be returned to members or used for their benefit.
 
 
 

--- a/statutes.md
+++ b/statutes.md
@@ -125,7 +125,7 @@ Every proposal that aims to dissolve the Federation must be put forward by the B
 
 The General Assembly will determine in which manner the Federation is dissolved and in which manner the dissolution is settled. 
 
-In case of dissolution, any remaining net assets of the AISBL shall be allocated to one or more non-profit organisations with similar purposes, as determined by the General Assembly. Under no circumstances may the assets be returned to members or used for their benefit.
+In case of dissolution, any remaining net assets of the AISBL shall be allocated to one or more non-profit legal persons pursuing a disinterested purpose similar to that of IFLRY, as designated by the General Assembly. Under no circumstances may the assets be returned to members or used for their benefit.
 
 
 

--- a/statuts.md
+++ b/statuts.md
@@ -125,4 +125,4 @@ Toute proposition visant à dissoudre la Fédération doit être introduite par 
 
 L'Assemblée générale détermine les modalités de dissolution de la Fédération et les modalités de liquidation.
 
-En cas de dissolution, l'actif net restant de l'AISBL est affecté à une ou plusieurs organisations sans but lucratif poursuivant un but similaire, telles que déterminées par l'Assemblée générale. En aucun cas les actifs ne peuvent être distribués aux membres ni utilisés à leur profit.
+En cas de dissolution, l'actif net restant de l'AISBL est affecté à une ou plusieurs personnes morales sans but lucratif poursuivant un but désintéressé similaire à celui d'IFLRY, telles que désignées par l'Assemblée générale. En aucun cas les actifs ne peuvent être distribués aux membres ni utilisés à leur profit.


### PR DESCRIPTION
## Summary
- Clarifies asset allocation upon dissolution to comply with Belgian law (WVV) by naming a specific non-profit purpose in the statutes rather than delegating entirely to a future GA decision
- Updates both English and French versions: "organisations with similar purposes" → "non-profit legal persons pursuing a disinterested purpose similar to that of IFLRY"

Closes #37