### PR TITLE
Add voluntary withdrawal of members

### DIFF
--- a/internal-regulations.md
+++ b/internal-regulations.md
@@ -120,10 +120,10 @@ An individual member who is not in good financial standing is automatically cons
 
 The members can leave the Federation on the following conditions:
 
-(a) The members of the Federation can resign by themselves.
+(a) Member organisations may withdraw from the association in accordance with the Statutes.
 (b) The members of the Federation can be expelled.
 
-A request for voluntary resignation by a member organisation needs to be filed with the Bureau through an official representative of the member organisation. The General Assembly validates this request before the member organisation is deregistered. In a case of the General Assembly not confirming the termination request, the membership will terminate at the end of the calendar year. A motion to expel a member can be submitted by the Bureau or two full members and needs to be submitted four weeks prior to the start of the General Assembly. Such a motion can be submitted if the targeted member organisation is suspected of breaching any of the membership obligations.
+A motion to expel a member can be submitted by the Bureau or two full members and needs to be submitted four weeks prior to the start of the General Assembly. Such a motion can be submitted if the targeted member organisation is suspected of breaching any of the membership obligations.
 
 Members need to be informed about this motion three weeks prior to the start of the statutory event. The Bureau is required to put forward a motion confirming the expulsion of any member which has retained candidate membership status for four years.
 

--- a/statutes.md
+++ b/statutes.md
@@ -76,7 +76,9 @@ All members commit themselves to fulfilling both of the following membership obl
 (a) to adhere to the financial obligations as stated in the Membership Fee Statute. Organisations and individual members which have fulfilled these obligations are considered in good financial standing;
 (b) to uphold the values as stated in the Manifesto.
 
-## Membership Suspension, Termination and Modification 
+## Membership Withdrawal, Suspension and Termination
+Any member organisation, other than the Individual Members Group, may withdraw from the association at any time by written notice to the Bureau. Withdrawal takes effect upon receipt of that notice and does not release the member from obligations already due.
+
 Member organisations and individual members can be temporarily suspended, or have their membership terminated, for breaches of membership obligations as described in [article](#mem-obligations) or other severe reasons. The voting procedure used for suspending or expelling an organisation is the same as would be used for admitting any other organisation of an equivalent membership type.
 
 # Statutory Bodies

--- a/statutes.md
+++ b/statutes.md
@@ -77,7 +77,7 @@ All members commit themselves to fulfilling both of the following membership obl
 (b) to uphold the values as stated in the Manifesto.
 
 ## Membership Withdrawal, Suspension and Termination
-Any member organisation, other than the Individual Members Group, may withdraw from the association at any time by written notice to the Bureau. Withdrawal takes effect upon receipt of that notice and does not release the member from obligations already due.
+Any Full, Associate, Observer or Regional Member organisation may withdraw from the association at any time by written notice to the Bureau. Withdrawal takes effect upon receipt of that notice and does not release the member from obligations already due.
 
 Member organisations and individual members can be temporarily suspended, or have their membership terminated, for breaches of membership obligations as described in [article](#mem-obligations) or other severe reasons. The voting procedure used for suspending or expelling an organisation is the same as would be used for admitting any other organisation of an equivalent membership type.
 

--- a/statuts.md
+++ b/statuts.md
@@ -76,7 +76,9 @@ Tous les membres s'engagent à respecter les deux obligations suivantes :
 (a) respecter les obligations financières telles que définies dans le Statut relatif aux cotisations. Les organisations et membres individuels ayant rempli ces obligations sont considérés comme étant en règle financièrement ;
 (b) respecter les valeurs telles qu'énoncées dans le Manifeste.
 
-## Suspension, Exclusion et Modification de l'adhésion
+## Retrait, Suspension et Exclusion
+Toute organisation membre, à l'exception du Groupe des Membres Individuels, peut se retirer de l'association à tout moment par notification écrite au Bureau. Le retrait prend effet dès réception de cette notification et ne libère pas le membre des obligations déjà échues.
+
 Les organisations membres et les membres individuels peuvent être temporairement suspendus ou voir leur adhésion résiliée en cas de violation des obligations des membres telles que décrites à l'[article](#mem-obligations) ou pour d'autres raisons graves. La procédure de vote utilisée pour suspendre ou exclure une organisation est la même que celle utilisée pour admettre toute autre organisation d'un type d'adhésion équivalent.
 
 # Organes statutaires

--- a/statuts.md
+++ b/statuts.md
@@ -77,7 +77,7 @@ Tous les membres s'engagent à respecter les deux obligations suivantes :
 (b) respecter les valeurs telles qu'énoncées dans le Manifeste.
 
 ## Retrait, Suspension et Exclusion
-Toute organisation membre, à l'exception du Groupe des Membres Individuels, peut se retirer de l'association à tout moment par notification écrite au Bureau. Le retrait prend effet dès réception de cette notification et ne libère pas le membre des obligations déjà échues.
+Toute organisation Membre Effectif, Associé, Observateur ou Régional peut se retirer de l'association à tout moment par notification écrite au Bureau. Le retrait prend effet dès réception de cette notification et ne libère pas le membre des obligations déjà échues.
 
 Les organisations membres et les membres individuels peuvent être temporairement suspendus ou voir leur adhésion résiliée en cas de violation des obligations des membres telles que décrites à l'[article](#mem-obligations) ou pour d'autres raisons graves. La procédure de vote utilisée pour suspendre ou exclure une organisation est la même que celle utilisée pour admettre toute autre organisation d'un type d'adhésion équivalent.
 


### PR DESCRIPTION
## Summary
- Adds a voluntary withdrawal provision to the Statutes (English and French), allowing any member organisation (except the IMG) to withdraw by written notice to the Bureau
- Simplifies the Internal Regulations by removing the old GA-validation resignation process and cross-referencing the Statutes instead

## Changes
- `statutes.md` — new section heading + voluntary withdrawal paragraph
- `statuts.md` — same in French
- `internal-regulations.md` — removed old resignation process, added Statutes cross-reference


Closes #34