### PR TITLE
Add minimum Bureau size and dismissal procedure

### DIFF
--- a/statutes.md
+++ b/statutes.md
@@ -102,12 +102,12 @@ An Extraordinary General Assembly can be called by a simple majority by the Bure
 ## The Bureau {#bureau}
 
 ### General
-The IFLRY Bureau consists of up to seven Bureau members elected by a General Assembly. The **Managing Bureau** consists of three Bureau members: **President**, **Secretary General**, and **Treasurer** who shall serve as the Board of Directors (Organe d’Administration) under Belgian Law. The **Bureau** consists of the Managing Bureau and up to four **Vice Presidents**. The Managing Bureau will be elected for a period of two years; the Vice Presidents will be elected for a period of one year. The election and responsibilities of the Bureau are described further in the Rules of Procedure.
+The IFLRY Bureau consists of at least three and no more than seven Bureau members elected by a General Assembly. The **Managing Bureau** consists of three Bureau members: **President**, **Secretary General**, and **Treasurer** who shall serve as the Board of Directors (Organe d’Administration) under Belgian Law. The **Bureau** consists of the Managing Bureau and up to four **Vice Presidents**. The Managing Bureau will be elected for a period of two years; the Vice Presidents will be elected for a period of one year. The election and responsibilities of the Bureau are described further in the Rules of Procedure.
 
 The Bureau is responsible for the day-to-day management of the Federation and for the control of all its resources. The Bureau has to report to the General Assembly. Regional Member Organisations can appoint Regional Bureau Appointees. Regional Bureau Appointees do not have voting rights in the Bureau.
 
-### Suspension and Resignation 
-Individual Bureau Members can be suspended from their Bureau. They can also be forced to resign by the General Assembly. The details of this process are explained in the Rules of Procedure.
+### Suspension, Resignation and Dismissal
+Individual Bureau Members can be suspended from their Bureau. A Bureau member may resign at any time by written notice to the Bureau. The General Assembly, whether ordinary or extraordinary, may dismiss a Bureau member by means of a motion of no-confidence. A motion of no-confidence requires a two-thirds majority to pass, unless it was submitted as an organisational proposal four weeks before the General Assembly, in which case a simple majority suffices.
 
 ### Legal Status
 The association shall be represented towards third parties and in legal matters by at least two members of the Managing Bureau acting jointly, unless otherwise specified by the Statutes or Belgian law.

--- a/statuts.md
+++ b/statuts.md
@@ -102,12 +102,12 @@ Une Assemblée générale extraordinaire peut être convoquée à la majorité s
 ## Le Bureau {#bureau}
 
 ### Généralités
-Le Bureau de l'IFLRY est composé d'un maximum de sept membres élus par l'Assemblée générale. Le **Bureau de gestion** est composé de trois membres : le **Président**, le **Secrétaire général** et le **Trésorier**, qui constituent l'organe d'administration conformément au droit belge. Le Bureau se compose du Bureau de gestion et d'un maximum de quatre **Vice-présidents**. Le Bureau de gestion est élu pour une durée de deux ans ; les Vice-présidents sont élus pour une durée d'un an. L'élection et les responsabilités du Bureau sont décrites plus en détail dans le Règlement d'ordre intérieur.
+Le Bureau de l'IFLRY est composé d'au moins trois et d'au plus sept membres élus par l'Assemblée générale. Le **Bureau de gestion** est composé de trois membres : le **Président**, le **Secrétaire général** et le **Trésorier**, qui constituent l'organe d'administration conformément au droit belge. Le Bureau se compose du Bureau de gestion et d'un maximum de quatre **Vice-présidents**. Le Bureau de gestion est élu pour une durée de deux ans ; les Vice-présidents sont élus pour une durée d'un an. L'élection et les responsabilités du Bureau sont décrites plus en détail dans le Règlement d'ordre intérieur.
 
 Le Bureau est responsable de la gestion journalière de la Fédération et du contrôle de toutes ses ressources. Le Bureau doit rendre compte à l'Assemblée générale. Les organisations membres régionales peuvent désigner des représentants régionaux au Bureau. Ces représentants ne disposent pas de droit de vote au sein du Bureau.
 
-### Suspension et Démission
-Les membres individuels du Bureau peuvent être suspendus de leurs fonctions. Ils peuvent également être contraints de démissionner par l'Assemblée générale. Les modalités de cette procédure sont précisées dans le Règlement d'ordre intérieur.
+### Suspension, Démission et Révocation
+Les membres individuels du Bureau peuvent être suspendus de leurs fonctions. Un membre du Bureau peut démissionner à tout moment par notification écrite au Bureau. L'Assemblée générale, qu'elle soit ordinaire ou extraordinaire, peut révoquer un membre du Bureau au moyen d'une motion de défiance. Une motion de défiance requiert une majorité des deux tiers pour être adoptée, sauf si elle a été soumise en tant que proposition organisationnelle quatre semaines avant l'Assemblée générale, auquel cas une majorité simple suffit.
 
 ### Statut juridique
 L'association est représentée à l'égard des tiers et en justice par au moins deux membres du Bureau de gestion agissant conjointement, sauf disposition contraire des Statuts ou du droit belge.


### PR DESCRIPTION
## Summary
- Sets minimum Bureau size of three (the Managing Bureau) alongside existing maximum of seven
- Replaces vague dismissal reference with actual no-confidence procedure lifted from the Rules of Procedure
- Adds voluntary resignation provision for Bureau members
- Updates both English and French versions

## Test plan
- [ ] Verify French translation is accurate
- [ ] Confirm with lawyer that the dismissal procedure satisfies the WVV mandatory element
- [ ] Check consistency with RoP Expulsion and Replacement section (lines 108–111)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)