### PR TITLE
Add explicit member rights to statutes (GA-approved)

### DIFF
--- a/statutes.md
+++ b/statutes.md
@@ -76,6 +76,11 @@ All members commit themselves to fulfilling both of the following membership obl
 (a) to adhere to the financial obligations as stated in the Membership Fee Statute. Organisations and individual members which have fulfilled these obligations are considered in good financial standing;
 (b) to uphold the values as stated in the Manifesto.
 
+## Membership Rights {#mem-rights}
+All members have the right to attend the General Assembly and to access the minutes and annual accounts of the association.
+
+Full Members have the right to vote at the General Assembly, to nominate candidates, and to put forward and amend proposals. Associate Members and the Individual Members Group have the right to vote and to put forward and amend proposals, subject to the limitations set out in the Rules of Procedure. Regional Members have the right to put forward resolutions and amendments. Observer Members have the right to observe proceedings but do not have voting rights.
+
 ## Membership Withdrawal, Suspension and Termination
 Any Full, Associate, Observer or Regional Member organisation may withdraw from the association at any time by written notice to the Bureau. Withdrawal takes effect upon receipt of that notice and does not release the member from obligations already due.
 

--- a/statuts.md
+++ b/statuts.md
@@ -76,6 +76,11 @@ Tous les membres s'engagent à respecter les deux obligations suivantes :
 (a) respecter les obligations financières telles que définies dans le Statut relatif aux cotisations. Les organisations et membres individuels ayant rempli ces obligations sont considérés comme étant en règle financièrement ;
 (b) respecter les valeurs telles qu'énoncées dans le Manifeste.
 
+## Droits des membres {#mem-rights}
+Tous les membres ont le droit de participer à l'Assemblée générale et d'accéder aux procès-verbaux et aux comptes annuels de l'association.
+
+Les Membres Effectifs ont le droit de vote à l'Assemblée générale, le droit de présenter des candidats, ainsi que le droit de soumettre et d'amender des propositions. Les Membres Associés et le Groupe des Membres Individuels ont le droit de vote et le droit de soumettre et d'amender des propositions, sous réserve des limitations prévues dans le Règlement d'ordre intérieur. Les Membres Régionaux ont le droit de soumettre des résolutions et des amendements. Les Membres Observateurs ont le droit d'observer les délibérations mais ne disposent pas du droit de vote.
+
 ## Retrait, Suspension et Exclusion
 Toute organisation Membre Effectif, Associé, Observateur ou Régional peut se retirer de l'association à tout moment par notification écrite au Bureau. Le retrait prend effet dès réception de cette notification et ne libère pas le membre des obligations déjà échues.
 


### PR DESCRIPTION
## Summary
- Adds a new **Membership Rights / Droits des membres** section to both `statutes.md` and `statuts.md`, as approved by the General Assembly.
- This is a split of #41: only the membership-rights addition is included here. The voting-rights change for the Individual Members Group (also in #41) is left for separate decision.

## Test plan
- [ ] Section renders correctly in built PDFs
- [ ] French and English texts match the GA-approved wording